### PR TITLE
Add lambda observability scaffold

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,16 @@
+python_sources()
+
+python_requirements()
+
+python_awslambda_layer(
+    name="lambda_layer",
+    requirements=["boto3", "openai"],
+)
+
+python_awslambda(
+    name="monitor_zip",
+    handler="lambda_handler.handler",
+    runtime="python3.11",
+    include_requirements=False,
+    dependencies=[":lambda_layer"],
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# lamdbamonitor
+# Lambda Monitor
+
+This project is a lightweight observability assistant for AWS Lambda functions.
+It demonstrates how to pull logs, analyze error patterns, and leverage OpenAI
+to summarize failures. If the error rate exceeds a threshold (5% by default),
+the tool emails a summary and suggested fix via SNS.
+
+## Folder layout
+
+```
+.
+├── lambda_monitor/        # Python package with monitoring helpers
+│   ├── __init__.py
+│   ├── ai_assistant.py    # OpenAI integration for summaries
+│   ├── analysis.py        # log analysis utilities
+│   ├── alerts.py          # send email alerts via SNS
+│   ├── cloudwatch.py      # fetch logs and metrics from CloudWatch
+│   └── monitor.py         # orchestration helpers
+└── README.md
+```
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Example functions
+
+### Pull logs from CloudWatch
+
+```python
+from lambda_monitor import fetch_recent_logs
+
+logs = fetch_recent_logs("my-lambda-function", minutes=10)
+```
+
+### Analyze common errors
+
+```python
+from lambda_monitor import find_common_errors
+
+errors = find_common_errors(logs)
+```
+
+### Summarize with AI
+
+```python
+from lambda_monitor import summarize_errors
+
+summary = summarize_errors([e for e, _ in errors], logs, api_key="sk-...")
+print(summary)
+```
+
+### Alert when failures exceed 5%
+
+```python
+from lambda_monitor import alert_on_failure
+
+alert_on_failure(
+    "my-lambda-function",
+    "arn:aws:sns:us-east-1:123456789012:my-topic",
+    minutes=10,
+    threshold=0.05,
+    openai_api_key="sk-...",  # optional
+)
+```
+
+`alert_on_failure` automatically calls OpenAI to summarize the recent logs and
+sends the result via SNS email when the failure rate crosses the threshold.
+
+## Packaging with Pants
+
+This repo includes a basic [Pants](https://www.pantsbuild.org/) setup to
+build a deployment package and Lambda layer. Install Pants by running:
+
+```bash
+curl -L -O https://static.pantsbuild.org/setup/pants && chmod +x pants
+```
+
+Package everything with:
+
+```bash
+./pants package ::
+```
+
+The resulting ZIP files will be placed in the `dist/` directory and can be
+uploaded directly to AWS.

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -1,0 +1,21 @@
+"""AWS Lambda entry point to invoke the monitoring logic."""
+from lambda_monitor import alert_on_failure
+
+def handler(event, context):
+    """Entry point for AWS Lambda."""
+    function_name = event.get("function_name")
+    topic_arn = event.get("sns_topic_arn")
+    minutes = event.get("minutes", 5)
+    threshold = event.get("threshold", 0.05)
+    region = event.get("region", "us-east-1")
+    openai_api_key = event.get("openai_api_key")
+    if not function_name or not topic_arn:
+        raise ValueError("function_name and sns_topic_arn are required")
+    return alert_on_failure(
+        function_name,
+        topic_arn,
+        minutes,
+        threshold,
+        region,
+        openai_api_key=openai_api_key,
+    )

--- a/lambda_monitor/__init__.py
+++ b/lambda_monitor/__init__.py
@@ -1,0 +1,16 @@
+"""Lambda observability utilities."""
+
+from .cloudwatch import fetch_recent_logs, get_failure_rate
+from .analysis import find_common_errors
+from .ai_assistant import summarize_errors
+from .alerts import send_email_alert
+from .monitor import alert_on_failure
+
+__all__ = [
+    "fetch_recent_logs",
+    "find_common_errors",
+    "summarize_errors",
+    "send_email_alert",
+    "get_failure_rate",
+    "alert_on_failure",
+]

--- a/lambda_monitor/ai_assistant.py
+++ b/lambda_monitor/ai_assistant.py
@@ -1,0 +1,45 @@
+"""Helpers for interacting with an AI model to summarize errors or propose fixes."""
+
+from typing import List, Optional
+
+import openai
+
+# Placeholder for integration with your favorite AI library (e.g. OpenAI, Anthropic)
+# The function below takes the top error messages and raw logs, then calls the model
+# to generate a short summary and potential fix. In a real deployment you would
+# provide API keys or use a local model.
+
+
+def summarize_errors(
+    top_errors: List[str],
+    logs: List[str],
+    model: str = "gpt-3.5-turbo",
+    api_key: Optional[str] = None,
+) -> str:
+    """Return an AI-generated summary for the given errors and logs.
+
+    Parameters
+    ----------
+    top_errors:
+        The most common error messages.
+    logs:
+        Recent log lines from CloudWatch.
+    model:
+        The chat model to use.
+    api_key:
+        Optional OpenAI API key to use for this request.
+    """
+    if api_key:
+        openai.api_key = api_key
+    prompt = (
+        "You are an observability assistant. Summarize the probable root causes\n"
+        "from these Lambda logs and suggest a fix if obvious.\n"
+        f"Top errors: {top_errors}\n"
+        f"Recent logs:\n" + "\n".join(logs[:20])
+    )
+
+    response = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response["choices"][0]["message"]["content"].strip()

--- a/lambda_monitor/alerts.py
+++ b/lambda_monitor/alerts.py
@@ -1,0 +1,9 @@
+"""Simple alerting utilities using Amazon SNS."""
+
+import boto3
+
+
+def send_email_alert(topic_arn: str, subject: str, message: str, region: str = "us-east-1") -> None:
+    """Publish an alert to an SNS topic that emails subscribers."""
+    client = boto3.client("sns", region_name=region)
+    client.publish(TopicArn=topic_arn, Subject=subject, Message=message)

--- a/lambda_monitor/analysis.py
+++ b/lambda_monitor/analysis.py
@@ -1,0 +1,24 @@
+import re
+from collections import Counter
+from typing import List, Tuple
+
+
+ERROR_PATTERNS = [
+    re.compile(r"Traceback \(.*?\)", re.DOTALL),
+    re.compile(r"ERROR[: ]+(.*)")
+]
+
+
+def find_common_errors(log_lines: List[str], top_n: int = 3) -> List[Tuple[str, int]]:
+    """Analyze log lines and return the most common error messages."""
+    errors = []
+    for line in log_lines:
+        for pattern in ERROR_PATTERNS:
+            match = pattern.search(line)
+            if match:
+                # Use the entire matched message or group 1 if available
+                msg = match.group(1) if match.groups() else match.group(0)
+                errors.append(msg.strip())
+                break
+    counts = Counter(errors)
+    return counts.most_common(top_n)

--- a/lambda_monitor/cloudwatch.py
+++ b/lambda_monitor/cloudwatch.py
@@ -1,0 +1,62 @@
+import boto3
+from datetime import datetime, timedelta
+from typing import List
+
+
+def get_failure_rate(function_name: str, minutes: int = 5, region: str = "us-east-1") -> float:
+    """Return the ratio of errors to invocations for the Lambda in the window."""
+    client = boto3.client("cloudwatch", region_name=region)
+    end_time = datetime.utcnow()
+    start_time = end_time - timedelta(minutes=minutes)
+
+    def metric_sum(name: str) -> float:
+        resp = client.get_metric_statistics(
+            Namespace="AWS/Lambda",
+            MetricName=name,
+            Dimensions=[{"Name": "FunctionName", "Value": function_name}],
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=minutes * 60,
+            Statistics=["Sum"],
+        )
+        return sum(dp.get("Sum", 0.0) for dp in resp.get("Datapoints", []))
+
+    invocations = metric_sum("Invocations")
+    errors = metric_sum("Errors")
+    return (errors / invocations) if invocations else 0.0
+
+
+def fetch_recent_logs(function_name: str, minutes: int = 5, region: str = "us-east-1") -> List[str]:
+    """Fetch CloudWatch log messages for the Lambda from the last ``minutes``.
+
+    Parameters
+    ----------
+    function_name:
+        Name of the Lambda function.
+    minutes:
+        Time window to fetch logs for.
+    region:
+        AWS region where the function runs.
+
+    Returns
+    -------
+    List[str]
+        Collected log messages.
+    """
+    client = boto3.client("logs", region_name=region)
+    log_group = f"/aws/lambda/{function_name}"
+    end_time = datetime.utcnow()
+    start_time = end_time - timedelta(minutes=minutes)
+
+    events = []
+    paginator = client.get_paginator("filter_log_events")
+    for page in paginator.paginate(
+        logGroupName=log_group,
+        startTime=int(start_time.timestamp() * 1000),
+        endTime=int(end_time.timestamp() * 1000),
+    ):
+        for event in page.get("events", []):
+            message = event.get("message")
+            if message:
+                events.append(message)
+    return events

--- a/lambda_monitor/monitor.py
+++ b/lambda_monitor/monitor.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from .cloudwatch import get_failure_rate, fetch_recent_logs
+from .analysis import find_common_errors
+from .ai_assistant import summarize_errors
+from .alerts import send_email_alert
+
+
+def alert_on_failure(
+    function_name: str,
+    topic_arn: str,
+    minutes: int = 5,
+    threshold: float = 0.05,
+    region: str = "us-east-1",
+    openai_api_key: Optional[str] = None,
+) -> bool:
+    """Check the failure rate and send an email alert if it exceeds the threshold.
+
+    Returns True if an alert was sent.
+    """
+    rate = get_failure_rate(function_name, minutes, region)
+    if rate > threshold:
+        logs = fetch_recent_logs(function_name, minutes, region)
+        top_errors = [e for e, _ in find_common_errors(logs)]
+        summary = summarize_errors(top_errors, logs, api_key=openai_api_key)
+        subject = f"Lambda {function_name} failure rate {rate:.1%}"
+        send_email_alert(topic_arn, subject, summary, region)
+        return True
+    return False

--- a/pants.toml
+++ b/pants.toml
@@ -1,0 +1,9 @@
+[GLOBAL]
+pants_version = "2.17.0"
+backend_packages = [
+    "pants.backend.python",
+    "pants.backend.awslambda.python",
+]
+
+[python]
+interpreter_constraints = ["CPython>=3.11,<3.12"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+openai


### PR DESCRIPTION
## Summary
- scaffold package `lambda_monitor` with helper modules
- document folder layout and example usage in README
- stub functions for CloudWatch log fetch, analysis, AI summary, and email alerts
- specify base Python dependencies
- update alerts to use SNS email instead of Slack
- openai integration in `summarize_errors`
- compute CloudWatch failure rate and send alert via `alert_on_failure`
- add Pants build files to package lambda and layer
- accept API key in `summarize_errors` and plumb through `alert_on_failure`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e73d2ecf083278df77aacb863a26f